### PR TITLE
Support uncoverable branches.

### DIFF
--- a/lib/Devel/Cover/Report/Codecov.pm
+++ b/lib/Devel/Cover/Report/Codecov.pm
@@ -80,6 +80,8 @@ sub get_file_coverage {
 sub get_line_coverage {
     my ($statement, $branch) = @_;
 
+    # If all branches covered or uncoverable, report as all covered
+    return $branch->[0]->total.'/'.$branch->[0]->total if $branch && !$branch->[0]->error;
     return $branch->[0]->covered.'/'.$branch->[0]->total if $branch;
     return $statement unless $statement;
     return if $statement->[0]->uncoverable;

--- a/t/codecov/get_line_coverage.t
+++ b/t/codecov/get_line_coverage.t
@@ -42,8 +42,19 @@ subtest branch => sub {
     my $branch = Test::MockObject->new;
     $branch->mock(covered => sub { 5 });
     $branch->mock(total => sub { 10 });
+    $branch->mock(error => sub { 5 });
 
     is get_line_coverage([ $statement ], [ $branch ]), '5/10';
+
+    subtest 'if uncoverable' => sub {
+        my $branch = Test::MockObject->new;
+        $branch->mock(covered => sub { 5 });
+        $branch->mock(total => sub { 10 });
+        $branch->mock(error => sub { 0 });
+
+        is get_line_coverage([ $statement ], [ $branch ]), '10/10';
+    };
+
 };
 
 done_testing;


### PR DESCRIPTION
This updates the reporting to say a branch is fully covered if all its parts are covered or marked as uncoverable.

Should fix #27 I think.