### PR TITLE
Https

### DIFF
--- a/META.json
+++ b/META.json
@@ -93,14 +93,15 @@
          "web" : "https://github.com/codecov/codecov-perl"
       }
    },
-   "version" : "0.22",
+   "version" : "0.23",
    "x_authority" : "cpan:PINE",
    "x_contributors" : [
       "Dagfinn Ilmari Mannsåker <ilmari@ilmari.org>",
       "M Somerville <dracos@users.noreply.github.com>",
       "Pedro Melo <melo@simplicidade.org>",
       "Pine Mizune <pinemz@gmail.com>",
-      "stevepeak <steve@stevepeak.net>"
+      "stevepeak <steve@stevepeak.net>",
+      "Álvaro Castellano <alvaro.castellano.vela@gmail.com>"
    ],
    "x_serialization_backend" : "JSON::PP version 2.27400_02"
 }

--- a/lib/Devel/Cover/Report/Codecov.pm
+++ b/lib/Devel/Cover/Report/Codecov.pm
@@ -2,7 +2,7 @@ package Devel::Cover::Report::Codecov;
 use strict;
 use warnings;
 use utf8;
-our $VERSION = '0.22';
+our $VERSION = '0.23';
 
 use URI;
 use Furl;
@@ -13,7 +13,7 @@ use Module::Find;
 useall 'Devel::Cover::Report::Codecov::Service';
 
 
-our $API_ENDPOINT = 'http://codecov.io/upload/v2';
+our $API_ENDPOINT = 'https://codecov.io/upload/v2';
 our $RETRY_TIMES  = 5;
 our $RETRY_DELAY  = 1; # sec
 

--- a/t/codecov/report.t
+++ b/t/codecov/report.t
@@ -32,7 +32,7 @@ subtest 'if service found' => sub {
 
             get_request_url => sub {
                 my ($url, $query) = @_;
-                is $url, 'http://codecov.io/upload/v2';
+                is $url, 'https://codecov.io/upload/v2';
                 cmp_deeply $query, { key => 'value' };
                 return 'http://www.example.com';
             },


### PR DESCRIPTION
Dear @pine , 

Yesterday I found that cover report was failing cause a 308 redirect from codecov webserver:
```308 Permanent Redirect
<html>
<head><title>308 Permanent Redirect</title></head>
<body bgcolor="white">
<center><h1>308 Permanent Redirect</h1></center>
<hr><center>nginx/1.13.12</center>
</body>
</html>```

I have changed API_ENDPOINT to https version, it seems to be working.

Best regards