### PR TITLE
Add support for GitHub Actions

### DIFF
--- a/lib/Devel/Cover/Report/Codecov/Service/GitHub.pm
+++ b/lib/Devel/Cover/Report/Codecov/Service/GitHub.pm
@@ -1,0 +1,33 @@
+package Devel::Cover::Report::Codecov::Service::GitHub;
+use strict;
+use warnings;
+use utf8;
+
+sub detect {
+    return $ENV{GITHUB_ACTIONS};
+}
+
+sub configuration {
+    (my $branch = $ENV{GITHUB_REF}) =~ s{^refs/heads/}{};
+
+    my $conf = {
+        service      => 'github-actions',
+        commit       => $ENV{GITHUB_SHA},
+        slug         => $ENV{GITHUB_REPOSITORY},
+        build        => $ENV{GITHUB_RUN_ID},
+        build_url    => "https://github.com/$ENV{GITHUB_REPOSITORY}/actions/runs/$ENV{GITHUB_RUN_ID}",
+        branch       => $branch,
+    };
+
+    if ($ENV{GITHUB_HEAD_REF}) {
+        (my $pr = $ENV{GITHUB_REF}) =~ s{^refs/pull/}{};
+        $pr =~ s{/merge$}{};
+        $conf->{pr} = $pr;
+        $conf->{branch} = $ENV{GITHUB_HEAD_REF};
+    }
+
+    return $conf;
+}
+
+1;
+__END__

--- a/t/codecov/service/github/configuration.t
+++ b/t/codecov/service/github/configuration.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings FATAL => 'all';
+use utf8;
+
+use lib '.';
+use t::Util;
+use Devel::Cover::Report::Codecov::Service::GitHub;
+
+subtest basic => sub {
+    local $ENV{GITHUB_REF}        = 'refs/heads/branch';
+    local $ENV{GITHUB_SHA}        = 'commit';
+    local $ENV{GITHUB_REPOSITORY} = 'owner/repo';
+    local $ENV{GITHUB_RUN_ID}     = 'run_id';
+
+    my $configuration = Devel::Cover::Report::Codecov::Service::GitHub->configuration;
+    cmp_deeply
+        $configuration,
+        {
+            service   => 'github-actions',
+            commit    => 'commit',
+            slug      => 'owner/repo',
+            build     => 'run_id',
+            build_url => 'https://github.com/owner/repo/actions/runs/run_id',
+            branch    => 'branch',
+        };
+};
+
+subtest pr => sub {
+    local $ENV{GITHUB_REF}        = 'refs/pull/num/merge';
+    local $ENV{GITHUB_SHA}        = 'commit';
+    local $ENV{GITHUB_REPOSITORY} = 'owner/repo';
+    local $ENV{GITHUB_RUN_ID}     = 'run_id';
+    local $ENV{GITHUB_HEAD_REF}   = 'refs/heads/branch';
+
+    my $configuration = Devel::Cover::Report::Codecov::Service::GitHub->configuration;
+    cmp_deeply
+        $configuration,
+        {
+            service   => 'github-actions',
+            commit    => 'commit',
+            slug      => 'owner/repo',
+            build     => 'run_id',
+            build_url => 'https://github.com/owner/repo/actions/runs/run_id',
+            branch    => 'refs/heads/branch',
+            pr        => 'num',
+        };
+};
+
+done_testing;

--- a/t/codecov/service/github/detect.t
+++ b/t/codecov/service/github/detect.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings FATAL => 'all';
+use utf8;
+
+use lib '.';
+use t::Util;
+use Devel::Cover::Report::Codecov::Service::GitHub;
+
+sub github { 'Devel::Cover::Report::Codecov::Service::GitHub' }
+
+subtest 'if GitHub' => sub {
+    local $ENV{GITHUB_ACTIONS} = 1;
+    ok( github->detect );
+};
+
+subtest 'if not GitHub' => sub {
+    local $ENV{GITHUB_ACTIONS} = 0;
+    ok( not github->detect );
+};
+
+done_testing;


### PR DESCRIPTION
Includes unit tests.
I know the PR test has a full ref in branch whereas the normal one strips refs/heads, but this matches the bash behaviour at https://github.com/codecov/codecov-bash/blob/master/codecov#L797-L816 so I thought I should be consistent.