### PR TITLE
Remove Accept header

### DIFF
--- a/lib/Devel/Cover/Report/Codecov.pm
+++ b/lib/Devel/Cover/Report/Codecov.pm
@@ -154,7 +154,7 @@ sub send_report_once {
     my ($url, $json) = @_;
 
     my $furl    = Furl->new;
-    my $headers = [ 'Accept' => 'application/json' ];
+    my $headers = [];
     my $res     = $furl->post($url, $headers, $json);
 
     my ($message, $ok);


### PR DESCRIPTION
Codecov has started rejecting reports sent, with a "Could not satisfy the request Accept header" message. Removing the Accept header, and it appears to work okay, accepting the report.
(Alternatively, if Codecov could accept the Accept header again, that would work too :) )